### PR TITLE
changed title of Pitcher column to Player since it already says Pitch…

### DIFF
--- a/webapp/templates/playerstats.html
+++ b/webapp/templates/playerstats.html
@@ -42,7 +42,7 @@
       <table id="PT" class="center" style="width:90%">
         <tr style="font-size:20px;">
           <th width="13%" style="text-align:left;"><u>Pitching</u></th>
-          <th width="22%" style="text-align:left;"><u>Pitcher</u></th>
+          <th width="22%" style="text-align:left;"><u>Player</u></th>
           <th width="7%" style="text-align:center;"><u>Wins</u></th>
           <th width="7%" style="text-align:center;"><u>ERA</u></th>
           <th width="7%" style="text-align:center;"><u>IP</u></th>


### PR DESCRIPTION
Giving you things in very small pieces so you can quickly review and Pull or present Yoda like wisdoms upon me. This is a 7 character change. I changed the title of the column from Pitcher to Player in the Pitching section of player stats. It already says Pitching right next to the column to isolate the pitchers away from the position players, so both sections now have the same heading for player name as "Player".