### PR TITLE
config changes to player and team modules, team also has simple sort …

### DIFF
--- a/backend/myutils.py
+++ b/backend/myutils.py
@@ -1,0 +1,64 @@
+"""
+myutils.py
+Author: Robert Becker
+Date: June 25, 2017
+Purpose: to house various common utilities
+
+load_config_file - loads config file into an object and returns
+get_config_value - retrieves value for section/key specified
+"""
+
+import configparser
+
+
+class ConfigLoadError(ValueError):
+    pass
+
+
+class ConfigKeyError(ValueError):
+    pass
+
+
+def load_config_file(config_file, logger):
+    """
+    :param config_file  name of config file to retrieve
+    :param logger       logger object to log messages during process
+
+    create and verify config object based on config file input
+    """
+
+    logger.info('Config file location: ' + config_file)
+
+    config = configparser.ConfigParser()
+
+    # open config file to verify existence and return object
+    try:
+        config.read_file(open(config_file))
+        config.read(config_file)
+    except Exception as e:
+        errmsg = 'Error loading Configuration file. . .'
+        logger.critical(errmsg)
+        logger.exception(e)
+        raise ConfigLoadError(errmsg)
+
+    return config
+
+
+def get_config_value(config_obj, logger, section, key):
+    """
+    :param config_file  name of config file to retrieve
+    :param logger       logger object to log messages during process
+    :param section      name of section to retrieve
+    :param key          name of key value to retrieve within section
+
+    retrieve value for section/key from config object
+    """
+
+    # verify key exists before retrieving and returning value
+    if config_obj.has_option(section, key):
+        config_value = config_obj.get(section, key)
+        return config_value
+    else:
+        errmsg = 'Config key ' + key + ' missing from section ' + section
+        logger.critical(errmsg)
+        raise ConfigKeyError(errmsg)

--- a/backend/updplayer.py
+++ b/backend/updplayer.py
@@ -15,12 +15,12 @@ import sys
 import os
 import shutil
 import argparse
-import configparser
 import logging
 import logging.config
 import datetime
 import json
 import requests
+import myutils
 
 
 # setup global variables
@@ -30,14 +30,6 @@ DAILY_SCHEDULE = 'schedule_YYYYMMDD.json'
 PLAYER_MSTR_I = 'playerMaster.json'
 PLAYER_MSTR_O = 'playerMaster_YYYYMMDD.json'
 BOXSCORE = 'http://gd2.mlb.com/_directory_/boxscore.json'
-
-
-class ConfigLoadError(ValueError):
-    pass
-
-
-class ConfigKeyError(ValueError):
-    pass
 
 
 class LoadDictionaryError(ValueError):
@@ -72,35 +64,6 @@ def get_command_arguments():
     logger.info('Command arguments: ' + str(argue.game_date))
 
     return argue
-
-
-def get_data_directory(config_file):
-    """
-    load config file to retrieve directory path for data files
-    """
-
-    logger.info('Config file location: ' + config_file)
-
-    config = configparser.ConfigParser()
-
-    # open config file to verify existence, then read and return
-    try:
-        config.read_file(open(config_file))
-        config.read(config_file)
-    except Exception as e:
-        errmsg = 'Error loading Configuration file. . .'
-        logger.critical(errmsg)
-        logger.exception(e)
-        raise ConfigLoadError(errmsg)
-
-    # verify DataPath key exists before setting path location
-    if config.has_option("DirectoryPaths", "DataPath"):
-        path = config.get("DirectoryPaths", "DataPath")
-        return path
-    else:
-        errmsg = 'Config DataPath key missing from DirectoryPaths section'
-        logger.critical(errmsg)
-        raise ConfigKeyError(errmsg)
 
 
 def determine_filenames(gamedate=None):
@@ -494,10 +457,13 @@ def main(gamedate=None):
 
     # get the data directory from the config file
     try:
-        path = get_data_directory(CONFIG_INI)
-    except ConfigLoadError:
+        section = "DirectoryPaths"
+        key = "DataPath"
+        config = myutils.load_config_file(CONFIG_INI, logger)
+        path = myutils.get_config_value(config, logger, section, key)
+    except myutils.ConfigLoadError:
         return 1
-    except ConfigKeyError:
+    except myutils.ConfigKeyError:
         return 2
 
     io = determine_filenames(gamedate)


### PR DESCRIPTION
Both the team and player update modules got the new config file logic to get the data directory.

Also cleaned up Player module for earned runs, used int() instead of float() to get earned runs from dictionary since there's no such thing as half a run. - 1 line change.

Team module also had bug due to random loading of dictionary in 3.4 (changed in 3.5 to stay sorted), so had to sort dictionary keys before staring loop as when processing a double header, game 2 must update the team after after game 1. - also a 1 line change.