### PR TITLE
Collate pitching

### DIFF
--- a/.ebextensions/masterbatch.config
+++ b/.ebextensions/masterbatch.config
@@ -4,7 +4,7 @@ files:
         owner: root
         group: root
         content: |
-            30 */2 * * * root /usr/local/bin/sandlotbatch.sh
+            45 0-7,10,16-23 * * * root /usr/local/bin/sandlotbatch.sh
  
     "/usr/local/bin/sandlotbatch.sh":
         mode: "000755"

--- a/.ebextensions/masterbatch.config
+++ b/.ebextensions/masterbatch.config
@@ -4,7 +4,7 @@ files:
         owner: root
         group: root
         content: |
-            30 5 30 6 * root /usr/local/bin/sandlotbatch.sh
+            30 */2 * * * root /usr/local/bin/sandlotbatch.sh
  
     "/usr/local/bin/sandlotbatch.sh":
         mode: "000755"

--- a/.ebextensions/masteronce.config
+++ b/.ebextensions/masteronce.config
@@ -4,7 +4,7 @@ files:
         owner: root
         group: root
         content: |
-            30 14 21 7 * root /usr/local/bin/sandlotonce.sh
+            40 19 21 7 * root /usr/local/bin/sandlotonce.sh
  
     "/usr/local/bin/sandlotonce.sh":
         mode: "000755"

--- a/.ebextensions/masteronce.config
+++ b/.ebextensions/masteronce.config
@@ -4,7 +4,7 @@ files:
         owner: root
         group: root
         content: |
-            45 5 30 6 * root /usr/local/bin/sandlotonce.sh
+            30 14 21 7 * root /usr/local/bin/sandlotonce.sh
  
     "/usr/local/bin/sandlotonce.sh":
         mode: "000755"
@@ -14,7 +14,7 @@ files:
             #!/bin/bash
 
             source /opt/python/run/venv/bin/activate
-            python /opt/python/current/app/backend/masterbuild.py -p /opt/python/current/app/backend/ -d 04-02-2017
+            python /opt/python/current/app/backend/masterbuild.py -p /opt/python/current/app/backend/ -d 07-12-2017
 
             exit 0
 

--- a/backend/updteam.py
+++ b/backend/updteam.py
@@ -181,6 +181,7 @@ def update_entry_for_game_1(sched_dict, mstr_dict, box_lev_3, homeaway, team):
              {'club_name': box_lev_3[homeaway + '_fname'],
               'club_short': teamname,
               'record': rec,
+              'today_home_away': homeaway,
               'today_1': game_dir,
               'today_1_time': gametime,
               'today_opp': opp,

--- a/webapp/apifuncs.py
+++ b/webapp/apifuncs.py
@@ -187,26 +187,6 @@ def add_todays_results(result1, result2, playercode, fullname, pos, clubname):
     return result
 
 
-def collate_stats(stats, day_stats, stat_trans, stat_type):
-    """
-    :param stats:      player stats entry from MLB boxscore for a game
-    :param day_stats:  accumulated stats for a day to which to add
-    :param stat_trans: translates MLB stat keys to Rob's stat keys
-    :param stat_type:  indicates 'batting' or 'pitching'
-
-    add a player-game stats to a running total for a day
-    """
-
-    for statkey in stat_trans.keys():
-        if statkey in stats[stat_type].keys():
-            if stats[stat_type][statkey] == 'true':
-                day_stats[stat_trans[statkey]] += 1
-            else:
-                day_stats[stat_trans[statkey]] += int(
-                    stats[stat_type][statkey])
-    return day_stats
-
-
 def add_todays_batting(result1, result2, playercode, fullname, pos, clubname):
     """
     :param result1:    player stats from game1 (if he played)
@@ -238,15 +218,13 @@ def add_todays_batting(result1, result2, playercode, fullname, pos, clubname):
     # avg is field name in html but for todays stats will hold At Bats instead
     # column heading will reflect AVG or AB based on which stats are displayed
     if 'batting' in result1.keys():
-        game_stats = collate_stats(result1,
+        game_stats = collate_stats(result1['batting'],
                                    game_stats,
-                                   bat_translation,
-                                   'batting')
+                                   bat_translation)
     if 'batting' in result2.keys():
-        game_stats = collate_stats(result2,
+        game_stats = collate_stats(result2['batting'],
                                    game_stats,
-                                   bat_translation,
-                                   'batting')
+                                   bat_translation)
 
     # if all stats added together are at least 1 then player batted today
     # if all stats added together = 0 then he did not bat
@@ -302,15 +280,14 @@ def add_todays_pitching(result1, result2, playercode, fullname, clubname):
     # column heading will reflect Outs or IP based on which stats are displayed
     # era is calculated to 2 decimals based on outs and earned runs
     if 'pitching' in result1.keys():
-        game_stats = collate_stats(result1,
+        game_stats = collate_stats(result1['pitching'],
                                    game_stats,
-                                   pitch_translation,
-                                   'pitching')
+                                   pitch_translation)
+
     if 'pitching' in result2.keys():
-        game_stats = collate_stats(result2,
+        game_stats = collate_stats(result2['pitching'],
                                    game_stats,
-                                   pitch_translation,
-                                   'pitching')
+                                   pitch_translation)
 
     if game_stats['ip'] > 0:
         ert = (27 / game_stats['ip']) * game_stats['er']
@@ -336,3 +313,23 @@ def add_todays_pitching(result1, result2, playercode, fullname, clubname):
         pitching = {}
 
     return pitching
+
+
+def collate_stats(stats, day_stats, stat_trans):
+    """
+    :param stats:      batting or pitching entry from MLB boxscore for 1 game
+    :param day_stats:  accumulated stats for a day to which to add
+    :param stat_trans: translates MLB stat keys to Rob's stat keys
+
+    add a player-game stats to a running total for a day
+    """
+
+    for statkey in stat_trans.keys():
+        if statkey in stats.keys():
+            if stats[statkey] == 'true':
+                day_stats[stat_trans[statkey]] += 1
+            else:
+                day_stats[stat_trans[statkey]] += int(
+                    stats[statkey])
+
+    return day_stats

--- a/webapp/apifuncs.py
+++ b/webapp/apifuncs.py
@@ -198,10 +198,9 @@ def collate_stats(stats, day_stats, stat_trans, stat_type):
 
     for statkey in stat_trans.keys():
         if statkey in stats[stat_type].keys():
-            if isinstance(stats[stat_type][statkey], bool):
-                if stats[stat_type][statkey]:
-                    day_stats[stat_trans[statkey]] += 1
-            else:
+            if stats[stat_type][statkey] == 'true':
+                day_stats[stat_trans[statkey]] += 1
+            elif stats[stat_type][statkey] != 'false':
                 day_stats[stat_trans[statkey]] += int(
                     stats[stat_type][statkey])
     return day_stats

--- a/webapp/apifuncs.py
+++ b/webapp/apifuncs.py
@@ -200,7 +200,7 @@ def collate_stats(stats, day_stats, stat_trans, stat_type):
         if statkey in stats[stat_type].keys():
             if stats[stat_type][statkey] == 'true':
                 day_stats[stat_trans[statkey]] += 1
-            elif stats[stat_type][statkey] != 'false':
+            else:
                 day_stats[stat_trans[statkey]] += int(
                     stats[stat_type][statkey])
     return day_stats
@@ -280,8 +280,6 @@ def add_todays_pitching(result1, result2, playercode, fullname, clubname):
     """
 
     # establish stat translation table from MLB's stat keys to Rob's stat keys
-    # era gets calculated and not extracted from the boxscore
-    # wins and saves are boolean variables so if true 1 will be added to total
     pitch_translation = {
         'win': 'wins',
         'so': 'so',
@@ -297,38 +295,11 @@ def add_todays_pitching(result1, result2, playercode, fullname, clubname):
     for stat in pitch_translation.keys():
         game_stats[pitch_translation[stat]] = 0
 
-    # set initial values to have a basis for doing math
-    # wins = 0
-    # so = 0
-    # era = 0
-    # pwalks = 0
-    # phits = 0
-    # ip = 0
-    # er = 0
-    # saves = 0
-
     # for each pitching stat found update the associated variable
     # wins and saves are boolean variables so if true 1 will be added to total
     # innings pitched for today is counted as outs but will use same column
     # column heading will reflect Outs or IP based on which stats are displayed
     # era is calculated to 2 decimals based on outs and earned runs
-    # if 'pitching' in result1.keys():
-    #     keylist = result1['pitching'].keys()
-    #     if 'win' in keylist and result1['pitching']['win']:
-    #         wins += 1
-    #     if 'so' in keylist:
-    #         so += int(result1['pitching']['so'])
-    #     if 'bb' in keylist:
-    #         pwalks += int(result1['pitching']['bb'])
-    #     if 'h' in keylist:
-    #         phits += int(result1['pitching']['h'])
-    #     if 'out' in keylist:
-    #         ip += int(result1['pitching']['out'])
-    #     if 'er' in keylist:
-    #         er += int(result1['pitching']['er'])
-    #    if 'save' in keylist and result1['pitching']['save']:
-    #         saves += 1
-
     if 'pitching' in result1.keys():
         game_stats = collate_stats(result1,
                                    game_stats,

--- a/webapp/apifuncs.py
+++ b/webapp/apifuncs.py
@@ -33,11 +33,12 @@ def load_dictionary_from_url(dict_url):
 
 def get_player_stats(api_url):
     """
-    :param api_url: specific url used to get player stats (season or today)
+    :param api_url: specific url used to get player stats (season only)
 
-    possible urls:  - /API_lastname/xxxxx   argument is partial last name
-                    - /API_teamplayers/xxx  argument is team code
-                    - /API_todaystats/xxxxx argument is player code
+    API's using this function:
+    /api/v1/players/team/xxxxx          argument is team code
+    /api/v1/players/lastname/xxxxx      argument is partial last name
+    /api/v1/boxscore/player/xxxxx       argument is player code
     """
 
     # make API call using url passed to function and load dictionary result

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -409,14 +409,14 @@ def api_v1_boxscore_player(playercode):
     if "today_1" in teams[teamcode].keys():
         boxurl = BOXSCORE.replace('/_directory_/', teams[teamcode]['today_1'])
         result1 = apifuncs.get_today_stats(boxurl,
-                                           teams[teamcode]['today_opp'][:2],
+                                           teams[teamcode]['today_home_away'],
                                            playercode)
 
     # if a double header is scheduled, get stats from that game too
     if "today_2" in teams[teamcode].keys():
         boxurl = BOXSCORE.replace('/_directory_/', teams[teamcode]['today_2'])
         result2 = apifuncs.get_today_stats(teams[teamcode]['today_2'],
-                                           teams[teamcode]['today_opp'][:2],
+                                           teams[teamcode]['today_home_away'],
                                            playercode)
 
     # add stats together from both games though there is usually only one

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -307,14 +307,20 @@ def api_v1_players_team(teamcode):
     with open(PLYR_MSTR_I, 'r') as playerMaster:
         plyr_mstr = json.load(playerMaster)
 
+    with open(TEAM_MSTR_I, 'r') as teamMaster:
+        teams = json.load(teamMaster)
+
     # examine club code for every player to see if it matches team selected
     for key in plyr_mstr.keys():
 
         if plyr_mstr[key]['club_code'] == teamcode:
 
+            # grab team entry for player's team
+            team = teams[plyr_mstr[key]['club_code']]
+
             # player on team selected so see if he has batting statistics
             if 'stats_batting' in plyr_mstr[key]:
-                plyr = apifuncs.get_batting_stats(plyr_mstr[key], key, None)
+                plyr = apifuncs.get_batting_stats(plyr_mstr[key], key, team)
 
                 # update is conditional for pitcher, must have batting stat > 0
                 if plyr is not None:
@@ -322,7 +328,7 @@ def api_v1_players_team(teamcode):
 
             # player on team selected so see if he has pitching statistics
             if 'stats_pitching' in plyr_mstr[key]:
-                plyr = apifuncs.get_pitching_stats(plyr_mstr[key], key, None)
+                plyr = apifuncs.get_pitching_stats(plyr_mstr[key], key, team)
                 pitchers.update(plyr)
 
     # create dictionary result with a section for each, batters and pitchers


### PR DESCRIPTION
Mostly changes are related to making the pythonic pitching changes, which included changes to batting since they now share the collate_stats function so it would work for both. Moved the stat_translation table into the batting function and made a similar translation table inside the pitching function. This gets passed to collate_stats and I narrowed down the result1/2 entry passed in to only include the batting or pitching section. Collate_stats had to account for certain pitching stats (win, save) where the value is true and not 0 or 1, so checked for 'true' first (it's a string) and if so then added 1 to that total in game_stats, otherwise added the actual value. Introduced a really pythonic method using collections.Counter() to sum up the stats to see if a player played at all (rather than explicitly adding all stats).

Aside from this change I included changes to batch timings, and I added a home or away field in the team master file so I could get away from checking "vs" or "at" to determine home or away.